### PR TITLE
Close popup window after res rights changed

### DIFF
--- a/frontend/src/components/AllUsers.jsx
+++ b/frontend/src/components/AllUsers.jsx
@@ -257,14 +257,14 @@ const AllUsers = ({
 
             {userDetailsResRights ? (
               <Button
-              onClick={() => handleResRightChange(userDetailsId)}
+              onClick={() => {handleResRightChange(userDetailsId); handleClose()}}
               sx={{ marginBottom: '1rem' }} // Add spacing below the button
               >
               {t("removeresrights")}
               </Button>
             ):
             <Button
-              onClick={() => handleResRightChange(userDetailsId)}
+              onClick={() => {handleResRightChange(userDetailsId); handleClose()}}
               sx={{ marginBottom: '1rem' }} // Add spacing below the button
             >
               {t("addresrights")}


### PR DESCRIPTION
- Fix issue #391, so that pop-up now closes after reservation rights have been changed (for submitting keys the issue has already been fixed) 